### PR TITLE
find best match based on length of string

### DIFF
--- a/wis2box_auth/base.py
+++ b/wis2box_auth/base.py
@@ -110,7 +110,7 @@ class BaseAuth:
 
         :returns: Topic Hierarchy string
         """
-        
+
         matches = []
         for topic in self.topics():
             if topic in fuzzy_topic:

--- a/wis2box_auth/base.py
+++ b/wis2box_auth/base.py
@@ -110,9 +110,17 @@ class BaseAuth:
 
         :returns: Topic Hierarchy string
         """
+        
+        matches = []
         for topic in self.topics():
             if topic in fuzzy_topic:
-                return topic
+                matches.append(topic)
+
+        if len(matches) == 1:
+            return matches[0]
+        elif len(matches) > 1:
+            # If there are multiple matches, return the longest one
+            return max(matches, key=len)
 
     def topics(self) -> Iterator[str]:
         """


### PR DESCRIPTION
To support users wishing to use separate auth-tokens for "processes/wis2box-publish_dataset" and "processes/wis2box-synop2bufr" , while still allowing other users wishing to use a single token for  "processes/wis2box" we need to be able to distinguish the best match based on length of string 

In support of https://github.com/World-Meteorological-Organization/wis2box/issues/905